### PR TITLE
04 Layout transition

### DIFF
--- a/app/src/main/java/com/karumi/androidanimations/layouttransition/ExerciseLayoutTransition.kt
+++ b/app/src/main/java/com/karumi/androidanimations/layouttransition/ExerciseLayoutTransition.kt
@@ -1,11 +1,18 @@
 package com.karumi.androidanimations.layouttransition
 
+import android.animation.Animator
+import android.animation.ObjectAnimator
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.annotation.LayoutRes
+import androidx.transition.ChangeBounds
 import androidx.transition.Scene
+import androidx.transition.Transition
+import androidx.transition.TransitionManager
+import androidx.transition.TransitionSet
+import androidx.transition.TransitionValues
 import com.karumi.androidanimations.R
 
 interface ExerciseLayoutTransition {
@@ -54,16 +61,42 @@ interface ExerciseLayoutTransition {
                     }
             }
 
-            TODO(
-                """
-                | Create a custom Transition to rotate views automatically if their "rotation"
-                | property changes.
-                |
-                | Use TransitionManager to animate views to the configured scene above.
-                | Remember the animation has to rotate the current view with your own implementation
-                | of a sharedElementTransition and move to the right position.
-                """.trimMargin()
+            TransitionManager.go(
+                scene,
+                TransitionSet()
+                    .addTransition(RotateTransition())
+                    .addTransition(ChangeBounds())
             )
         }
+    }
+}
+
+class RotateTransition : Transition() {
+    companion object {
+        private const val ROTATION_KEY = "androidanimations:rotation:rotation"
+    }
+
+    override fun captureStartValues(transitionValues: TransitionValues) {
+        val rotation = transitionValues.view.rotation
+        transitionValues.values[ROTATION_KEY] = rotation
+    }
+
+    override fun captureEndValues(transitionValues: TransitionValues) {
+        val rotation = transitionValues.view.rotation
+        transitionValues.values[ROTATION_KEY] = rotation
+    }
+
+    override fun createAnimator(
+        sceneRoot: ViewGroup,
+        startValues: TransitionValues?,
+        endValues: TransitionValues?
+    ): Animator? {
+        startValues ?: return null
+        endValues ?: return null
+
+        val startRotation = startValues.values.getOrElse(ROTATION_KEY, { 0f }) as Float
+        val endRotation = endValues.values.getOrElse(ROTATION_KEY, { 0f }) as Float
+
+        return ObjectAnimator.ofFloat(endValues.view, View.ROTATION, startRotation, endRotation)
     }
 }


### PR DESCRIPTION
Solve the exercise for layout transitions.

In this case we need to create our own `Transition` implementation to get a rotation. We can do it in several ways, we opted for dealing with the `rotation` property of views and combine it with a regular `ChangeBounds` transitions through a `TransitionSet`.
There is no need to create explicit animations because `TransitionManager` will create them for us. We just need to tell them two layouts with matching views so that it can analyze what animations are required to transform the starting scene into the final scene.

You can see the animation here:

![device-2019-05-14-170205 2019-05-14 17_03_06](https://user-images.githubusercontent.com/3116415/57709083-b6620980-766a-11e9-8efa-cc2207c93424.gif)
