### PR TITLE
05A Shared elements

### DIFF
--- a/app/src/main/java/com/karumi/androidanimations/sharedelements/SharedElementsExerciseTransitionFragment.kt
+++ b/app/src/main/java/com/karumi/androidanimations/sharedelements/SharedElementsExerciseTransitionFragment.kt
@@ -6,16 +6,75 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.AccelerateInterpolator
+import android.view.animation.DecelerateInterpolator
 import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
+import androidx.navigation.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.transition.ArcMotion
+import androidx.transition.ChangeBounds
+import androidx.transition.ChangeTransform
+import androidx.transition.Fade
+import androidx.transition.Transition
+import androidx.transition.TransitionListenerAdapter
+import androidx.transition.TransitionSet
 import com.karumi.androidanimations.R
 import com.karumi.androidanimations.base.BaseFragment
 import com.karumi.androidanimations.common.CircularView
+import com.karumi.androidanimations.common.GlobalPositionTransition
+import com.karumi.androidanimations.common.RadiusTransition
 import com.karumi.androidanimations.extensions.px
 import kotlinx.android.synthetic.main.fragment_shared_elements_exercise_transition.*
+import kotlin.math.hypot
 
 class SharedElementsExerciseTransitionFragment : BaseFragment() {
+
+    companion object {
+        private const val easinessFactor = 1.2f
+
+        private val arcMotion = ArcMotion().apply {
+            minimumHorizontalAngle = 45f
+            minimumVerticalAngle = 45f
+        }
+
+        private val <T: Transition> T.accelerated: T
+            get() {
+                interpolator = AccelerateInterpolator(easinessFactor)
+                return this
+            }
+
+        private val <T: Transition> T.decelerated: T
+            get() {
+                interpolator = DecelerateInterpolator(easinessFactor)
+                return this
+            }
+
+        private val <T: Transition> T.withArc: T
+            get() {
+                setPathMotion(arcMotion)
+                return this
+            }
+
+        val enterSharedElementTransition
+            get() = TransitionSet()
+                .addTransition(GlobalPositionTransition().accelerated.withArc)
+                .addTransition(RadiusTransition().decelerated)
+                .apply { ordering = TransitionSet.ORDERING_SEQUENTIAL }
+
+        val exitSharedElementTransition
+            get() = TransitionSet()
+                .addTransition(RadiusTransition().accelerated)
+                .addTransition(
+                    TransitionSet()
+                        .addTransition(ChangeBounds())
+                        .addTransition(ChangeTransform())
+                        .decelerated
+                        .withArc
+                ).apply { ordering = TransitionSet.ORDERING_SEQUENTIAL }
+
+        val defaultTransition get() = Fade()
+    }
 
     private val args: SharedElementsExerciseTransitionFragmentArgs by navArgs()
 
@@ -28,17 +87,11 @@ class SharedElementsExerciseTransitionFragment : BaseFragment() {
         container,
         false
     ).also {
+        enterTransition = defaultTransition
+        exitTransition = defaultTransition
+        sharedElementReturnTransition = exitSharedElementTransition
+        sharedElementEnterTransition = fadeInColorNameAfterTransitionFinishes()
         postponeEnterTransition()
-        TODO(
-            """
-            | Create a transition in this very same fragment that makes the selected CircularView
-            | transform into the background of this fragment. Use a PathMotion to make the view
-            | follow an arc.
-            | The circular view has to go to the top-left corner with its actual shape and once
-            | there it has to start animating its radius to cover the whole screen.
-            | Make the color name view appear with a slight up movement and a fade effect.
-        """.trimMargin()
-        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -51,6 +104,8 @@ class SharedElementsExerciseTransitionFragment : BaseFragment() {
             configureBackgroundView(background)
             startPostponedEnterTransition()
         }
+
+        fadeOutColorNameBeforeClosingFragment()
     }
 
     @SuppressLint("ResourceAsColor")
@@ -59,12 +114,43 @@ class SharedElementsExerciseTransitionFragment : BaseFragment() {
         background.setBackgroundColor(args.color.colorInt)
         val offset = 24.px
         background.center = PointF(0f, 0f)
-        background.radius = Math.hypot(
+        background.radius = hypot(
             background.measuredWidth.toDouble() + offset,
             background.measuredHeight.toDouble() + offset
         ).toFloat()
         background.left -= offset
         background.top -= offset
+    }
+
+    private fun fadeInColorNameAfterTransitionFinishes() = enterSharedElementTransition.apply {
+        addListener(object : TransitionListenerAdapter() {
+            override fun onTransitionEnd(transition: Transition) {
+                colorName ?: return
+
+                colorName.animate()
+                    .alpha(1f)
+                    .translationY(0f)
+                    .start()
+            }
+        })
+    }
+
+    private fun fadeOutColorNameBeforeClosingFragment() {
+        requireActivity().onBackPressedDispatcher.addCallback {
+            val colorName = colorName ?: return@addCallback false
+            colorName.animate()
+                .alpha(0f)
+                .translationY(24.px.toFloat())
+                .apply { duration = 200 }
+                .withEndAction {
+                    colorName.visibility = View.GONE
+                    requireActivity()
+                        .findNavController(R.id.hostFragment)
+                        .popBackStack()
+                }
+                .start()
+            return@addCallback true
+        }
     }
 
     private val SharedElementsExerciseTransition.Color.backgroundView: CircularView?

--- a/app/src/main/java/com/karumi/androidanimations/sharedelements/SharedElementsFragment.kt
+++ b/app/src/main/java/com/karumi/androidanimations/sharedelements/SharedElementsFragment.kt
@@ -78,6 +78,10 @@ class SharedElementsFragment : BaseFragment() {
         color: SharedElementsExerciseTransition.Color,
         sharedElements: SharedElementsExerciseTransition.SharedElements
     ) {
+        sharedElementEnterTransition =
+            SharedElementsExerciseTransitionFragment.exitSharedElementTransition
+        exitTransition = SharedElementsExerciseTransitionFragment.defaultTransition
+
         val args = SharedElementsExerciseTransitionFragmentArgs(color)
 
         findNavController().navigate(


### PR DESCRIPTION
This exercise has been the hardest so far. The problem is to create a transition between two fragments sharing an element.

It starts with 4 circular views, when one of them is clicked, it moves to the top-left corner and expands to fill the whole screen. Once it finishes we show the name of the color with a short animation mixing both, a fade in transition and a move-up transition.

The result seems trivial but that's only because we are using some transitions I defined in the `master` branch like `RadiusTransition` and `GlobalPositionTransition`, you can take a look to those if you want to better understand how the animation works.

Here is how the animation looks like:

![device-2019-05-14-181636 2019-05-14 18_19_52](https://user-images.githubusercontent.com/3116415/57714482-e6aea580-7674-11e9-990c-be5548e0dde0.gif)
 