### PR TITLE
00B Path drawing with matrix transformation

### DIFF
--- a/app/src/main/java/com/karumi/androidanimations/pathdrawing/PathDrawingFragment.kt
+++ b/app/src/main/java/com/karumi/androidanimations/pathdrawing/PathDrawingFragment.kt
@@ -1,11 +1,16 @@
 package com.karumi.androidanimations.pathdrawing
 
+import android.graphics.Matrix
+import android.graphics.Path
+import android.graphics.RectF
 import android.os.Bundle
+import android.util.DisplayMetrics
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.karumi.androidanimations.R
 import com.karumi.androidanimations.base.BaseFragment
+import kotlinx.android.synthetic.main.fragment_path_drawing.*
 
 class PathDrawingFragment : BaseFragment() {
     override fun onCreateView(
@@ -16,15 +21,70 @@ class PathDrawingFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        TODO(
-            """
-            |Draw the exercise path on screen. You can use absolute coordinates or relative ones.
-            |If you follow the relative path (pwn intended), you can use DisplayMetrics:
-            |
-            |  val displayMetrics = DisplayMetrics()
-            |  requireActivity().windowManager.defaultDisplay.getMetrics(displayMetrics)
-            |  displayMetrics.widthPixels
-        """.trimMargin()
-        )
+
+        /**
+         *  ┌───────┬─────────┬>──────────────────┐
+         *  │(-1,-1)│       ┌─┘ ╲                 │
+         *  ├───────┘     ┌─┘  │ ╲                │
+         *  │           ┌─┘       ╲               │
+         *  │     ┌─────┴┐     │   ╲ ┌─────┐      │
+         *  │     │A line│          ╲┤B arc├──╲   │
+         *  │     ├──────┘     │     └─────┘   ╲  │
+         *  │   ┌─┘                             ╲ │
+         * ┌┴┐┌─┘              │                 ╲│
+         * │█├┴ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┬─▼
+         * └┬┘                 │              ┌─┘ │
+         *  │ ▲                             ┌─┘   │
+         *  │  ╲  ┌─────┐      │     ┌──────┤     │
+         *  │   ╲ │D arc│            │C line│     │
+         *  │    ╲┴─────┴──╲   │     └┬─────┘     │
+         *  │               ╲       ┌─┘           │
+         *  │                ╲ │  ┌─┘     ┌───────┤
+         *  │                 ╲ ┌─┘       │ (1,1) │
+         *  └──────────────────<┴─────────┴───────┘
+         */
+
+        val path = Path().apply {
+            moveTo(-1f, 0f)
+            /* A line */ lineTo(0f, -1f)
+            /* B arc  */ arcTo(RectF(0f, -2f, 2f, 0f), 180f, -90f)
+            /* C line */ lineTo(0f, 1f)
+            /* D arc  */arcTo(RectF((-2f), 0f, 0f, 2f), 0f, -90f)
+            transform(transformMatrix)
+        }
+
+        val xAxisPath = Path().apply {
+            moveTo(-1f, 0f)
+            lineTo(1f, 0f)
+            transform(transformMatrix)
+        }
+
+        val yAxisPath = Path().apply {
+            moveTo(0f, (-1f))
+            lineTo(0f, 1f)
+            transform(transformMatrix)
+        }
+
+        val boundsPath = Path().apply {
+            addRect(RectF(-1f, -1f, 1f, 1f), Path.Direction.CW)
+            transform(transformMatrix)
+        }
+
+        paintView += path to 0xFFE62A65.toInt()
+        paintView += xAxisPath to 0xFF323443.toInt()
+        paintView += yAxisPath to 0xFF323443.toInt()
+        paintView += boundsPath to 0xFF323443.toInt()
+    }
+
+    private val transformMatrix: Matrix by lazy {
+        val displayMetrics = DisplayMetrics()
+        requireActivity().windowManager.defaultDisplay.getMetrics(displayMetrics)
+
+        val scaleFactor = displayMetrics.widthPixels / 2.2f
+
+        Matrix().apply {
+            setScale(scaleFactor, scaleFactor)
+            preTranslate(1.1f, 1.1f)
+        }
     }
 }


### PR DESCRIPTION
Same exercise as in #7 

![image](https://user-images.githubusercontent.com/3116415/57717053-a3573580-767a-11e9-83f8-c6a2fac2f8c1.png)

We are still using points between -1 and 1 but instead of scaling each point we are now scaling the view with a transformation matrix. Same results:

![image](https://user-images.githubusercontent.com/3116415/57717107-c41f8b00-767a-11e9-864f-5d8c65ec10b9.png)

